### PR TITLE
update version checkstyle.jar

### DIFF
--- a/checkstyle/Dockerfile
+++ b/checkstyle/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod +x linter
 
 COPY google_checks_hexlet_edition.xml google_checks_hexlet_edition.xml
 
-RUN wget --quiet "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.32/checkstyle-8.32-all.jar" -O checkstyle.jar
+RUN wget --quiet "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.35/checkstyle-8.35-all.jar" -O checkstyle.jar
 
 ADD app /usr/src/app
 


### PR DESCRIPTION
Upgrade from version 8.32 to version 8.35.
Checking new features from java 14 is supported.

https://checkstyle.org/releasenotes.html#Release_8.35