### PR TITLE
Update checkstyle from 8.35 to 8.36.

### DIFF
--- a/checkstyle/Dockerfile
+++ b/checkstyle/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod +x linter
 
 COPY google_checks_hexlet_edition.xml google_checks_hexlet_edition.xml
 
-RUN wget --quiet "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.35/checkstyle-8.35-all.jar" -O checkstyle.jar
+RUN wget --quiet "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.36/checkstyle-8.36-all.jar" -O checkstyle.jar
 
 ADD app /usr/src/app
 


### PR DESCRIPTION
Fixed errors in the parsing of the switch-case syntax.