### PR TITLE
update sqlfluff & use cli options instead config file

### DIFF
--- a/sqlint/Dockerfile
+++ b/sqlint/Dockerfile
@@ -3,9 +3,8 @@ FROM python:3.8-alpine
 WORKDIR /linter
 
 # https://docs.sqlfluff.com/en/stable/
-RUN pip install -U --target ./lib sqlfluff==0.6.4
+RUN pip install -U --target ./lib sqlfluff==0.7.1
 
 COPY linter .
-COPY setup.cfg .
 
 CMD ./linter

--- a/sqlint/linter
+++ b/sqlint/linter
@@ -3,4 +3,4 @@
 LINTER_HOME=$(dirname $0)
 export PYTHONPATH=$LINTER_HOME/lib
 
-python3 -m sqlfluff lint /usr/src/app
+python3 -m sqlfluff lint /usr/src/app --dialect=postgres

--- a/sqlint/setup.cfg
+++ b/sqlint/setup.cfg
@@ -1,4 +1,0 @@
-[sqlfluff]
-dialect = postgres
-; TODO: L014 is triggered for keywords, not just identifiers
-exclude_rules = L014


### PR DESCRIPTION
При таком запуске как у нас sqlfluff нет возможности заставить использовать общий конфиг. Есть возможность использовать конфиг в каждой из практик, но в случае общей логики это неудобно.
Потому перенёс конфигурацию в запуск cli.

Также обновил сам линтер, часть ошибок там пофиксили и теперь нет необходимости дополнительно игнорить правило L014, в т.ч. на это влияет указание диалекта