### PR TITLE
update checkstyle

### DIFF
--- a/checkstyle/Dockerfile
+++ b/checkstyle/Dockerfile
@@ -1,10 +1,10 @@
-FROM openjdk:20-slim
+FROM openjdk:21-slim
 
 RUN apt-get update && apt-get install -yq wget
 
 WORKDIR /linter
 
-RUN wget -q "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.12.1/checkstyle-10.12.1-all.jar" -O checkstyle.jar
+RUN wget -q "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.17.0/checkstyle-10.17.0-all.jar" -O checkstyle.jar
 
 COPY linter .
 COPY sun_checks_hexlet_edition.xml .

--- a/checkstyle/app/example.java
+++ b/checkstyle/app/example.java
@@ -5,4 +5,8 @@ public class HelloWorld
 
   }
 
+    public String doGreeting() {
+        return "Hello";
+    }
+
 }

--- a/checkstyle/sun_checks_hexlet_edition.xml
+++ b/checkstyle/sun_checks_hexlet_edition.xml
@@ -177,7 +177,7 @@
 
     <!-- Checks for class design                         -->
     <!-- See https://checkstyle.org/config_design.html -->
-    <module name="DesignForExtension"/>
+    <!-- <module name="DesignForExtension"/> -->
     <module name="FinalClass"/>
     <!-- <module name="HideUtilityClassConstructor"/> -->
     <module name="InterfaceIsType"/>


### PR DESCRIPTION
Заглушил правило, которое требует писать javadoc комментарии к публичным не статическим методам. С Кириллом согласовано. Заодно обновил версии